### PR TITLE
Compound types

### DIFF
--- a/aom/src/aom_decoder.c
+++ b/aom/src/aom_decoder.c
@@ -114,15 +114,6 @@ aom_image_t *aom_codec_get_frame(aom_codec_ctx_t *ctx, aom_codec_iter_t *iter) {
   else
     img = ctx->iface->dec.get_frame(get_alg_priv(ctx), iter);
 
-  // uint8_t *luma = img->planes[AOM_PLANE_Y];
-  // fprintf(stderr, "(y_index, x_index, index) -> luma_value\n");
-  // for (int y =0; y < img->h; y++) {
-  //   for (int x = 0; x < img->w; x++) {
-      
-  //     int index = y * img->stride[AOM_PLANE_Y] + x;
-  //     fprintf(stderr, "(%d %d, %d) -> %d\n", y, x, index, luma[index]);
-  //   }
-  // }
   return img;
 }
 

--- a/aom/src/aom_decoder.c
+++ b/aom/src/aom_decoder.c
@@ -114,6 +114,15 @@ aom_image_t *aom_codec_get_frame(aom_codec_ctx_t *ctx, aom_codec_iter_t *iter) {
   else
     img = ctx->iface->dec.get_frame(get_alg_priv(ctx), iter);
 
+  // uint8_t *luma = img->planes[AOM_PLANE_Y];
+  // fprintf(stderr, "(y_index, x_index, index) -> luma_value\n");
+  // for (int y =0; y < img->h; y++) {
+  //   for (int x = 0; x < img->w; x++) {
+      
+  //     int index = y * img->stride[AOM_PLANE_Y] + x;
+  //     fprintf(stderr, "(%d %d, %d) -> %d\n", y, x, index, luma[index]);
+  //   }
+  // }
   return img;
 }
 

--- a/av1/decoder/inspection.c
+++ b/av1/decoder/inspection.c
@@ -96,11 +96,18 @@ int ifd_inspect(insp_frame_data *fd, void *decoder, int skip_not_transform) {
       }
 
       mi->motion_mode = mbmi->motion_mode;
-      mi->compound_type = mbmi->interinter_comp.type;
-      if (mbmi->interinter_comp.type == COMPOUND_WEDGE) { 
-        mi->wedge[0] = mbmi->interinter_comp.wedge_index;
-        mi->wedge[1] = mbmi->interinter_comp.wedge_sign;
+
+      if (mbmi->ref_frame[1] > INTRA_FRAME) {
+        mi->compound_type = mbmi->interinter_comp.type;
+        if (mbmi->interinter_comp.type == COMPOUND_WEDGE) { 
+          mi->wedge[0] = mbmi->interinter_comp.wedge_index;
+          mi->wedge[1] = mbmi->interinter_comp.wedge_sign;
+        } else {
+          mi->wedge[0] = -1;
+          mi->wedge[1] = -1;
+        }
       } else {
+        mi->compound_type = -1;
         mi->wedge[0] = -1;
         mi->wedge[1] = -1;
       }

--- a/av1/decoder/inspection.c
+++ b/av1/decoder/inspection.c
@@ -97,6 +97,13 @@ int ifd_inspect(insp_frame_data *fd, void *decoder, int skip_not_transform) {
 
       mi->motion_mode = mbmi->motion_mode;
       mi->compound_type = mbmi->interinter_comp.type;
+      if (mbmi->interinter_comp.type == COMPOUND_WEDGE) { 
+        mi->wedge[0] = mbmi->interinter_comp.wedge_index;
+        mi->wedge[1] = mbmi->interinter_comp.wedge_sign;
+      } else {
+        mi->wedge[0] = -1;
+        mi->wedge[1] = -1;
+      }
 
       // Block Size
       mi->bsize = mbmi->bsize;

--- a/av1/decoder/inspection.h
+++ b/av1/decoder/inspection.h
@@ -55,6 +55,7 @@ struct insp_mi_data {
   int16_t intrabc;
   int16_t palette;
   int16_t uv_palette;
+  int16_t wedge[2]; // [wedge_index, wedge_sign]
 };
 
 typedef struct insp_frame_data insp_frame_data;

--- a/av1/encoder/speed_features.c
+++ b/av1/encoder/speed_features.c
@@ -889,7 +889,7 @@ static void set_good_speed_features_framesize_independent(
     // TODO(any): Move this from speed 3 to speed 2 so that TPL multithread
     // is re-enabled at speed 2. This also makes encoder faster. After TPL MT is
     // fixed and works with compound pred, we can re-evaluate this feature.
-    sf->tpl_sf.allow_compound_pred = 0;
+    sf->tpl_sf.allow_compound_pred = 1;
     sf->tpl_sf.prune_ref_frames_in_tpl = 1;
   }
 

--- a/examples/inspect.c
+++ b/examples/inspect.c
@@ -40,6 +40,7 @@
 #include "common/tools_common.h"
 #include "common/video_common.h"
 #include "common/video_reader.h"
+#include "av1/common/reconinter.h"
 
 // Max JSON buffer size.
 const int MAX_BUFFER = 1024 * 1024 * 256;
@@ -189,6 +190,14 @@ const map_entry tx_size_map[] = {
   ENUM(TX_32X8),  ENUM(TX_16X64), ENUM(TX_64X16), LAST_ENUM
 };
 
+const map_entry frame_type_map[] = {
+  ENUM(KEY_FRAME),
+  ENUM(INTER_FRAME),
+  ENUM(INTRA_ONLY_FRAME),  // replaces intra-only
+  ENUM(S_FRAME),
+  LAST_ENUM
+};
+
 const map_entry tx_type_map[] = { ENUM(DCT_DCT),
                                   ENUM(ADST_DCT),
                                   ENUM(DCT_ADST),
@@ -230,6 +239,7 @@ const map_entry motion_mode_map[] = { ENUM(SIMPLE_TRANSLATION),
                                       LAST_ENUM };
 
 const map_entry compound_type_map[] = { ENUM(COMPOUND_AVERAGE),
+                                        ENUM(COMPOUND_DISTWTD),
                                         ENUM(COMPOUND_WEDGE),
                                         ENUM(COMPOUND_DIFFWTD), LAST_ENUM };
 
@@ -277,6 +287,7 @@ struct parm_offset parm_offsets[] = {
   { "compound_type", offsetof(insp_mi_data, compound_type) },
   { "referenceFrame", offsetof(insp_mi_data, ref_frame) },
   { "skip", offsetof(insp_mi_data, skip) },
+  { "wedge_sign", offsetof(insp_mi_data, wedge) }
 };
 int parm_count = sizeof(parm_offsets) / sizeof(parm_offsets[0]);
 
@@ -568,6 +579,83 @@ int put_block_info(char *buffer, const map_entry *map, const char *name,
   return (int)(buf - buffer);
 }
 
+int put_wedge_codebook(char *buffer, const wedge_code_type code_type) {
+  char *buf = buffer;
+  *(buf++) = '{';
+  buf += snprintf(buf, MAX_BUFFER, "\"wedgeDirectionType\" : %d,", code_type.direction);
+  buf += snprintf(buf, MAX_BUFFER, "\"x_offset\" : %d,", code_type.x_offset);
+  buf += snprintf(buf, MAX_BUFFER, "\"y_offset\" : %d }", code_type.y_offset);
+  
+  return (int)(buf - buffer);
+}
+
+int put_wedge_codebook_arr(char *buffer, const wedge_code_type *code_types, int size) { 
+
+  char *buf = buffer;
+  *(buf++) = '[';
+  int i;
+  for (i = 0; i < size; i++) {
+    buf += put_wedge_codebook(buf, code_types[i]);
+    if (i < size - 1) *(buf++) = ',';
+  }
+  *(buf++) = ']';
+
+  return (int)(buf - buffer);
+}
+
+int put_wedge_type(char *buffer, const wedge_params_type params) {
+  char *buf = buffer;
+  int i;
+
+  *(buf++) = '{';
+
+  buf += snprintf(buf, MAX_BUFFER, "\"wedge_types\": %d,", params.wedge_types);
+  buf += put_str(buf, "\"codebook\": ");
+  buf += put_wedge_codebook_arr(buf, params.codebook, params.wedge_types);
+  *(buf++) = ',';
+
+  buf += put_str(buf, "\"signflip\": [");
+
+  if (params.signflip) {
+    for (i = 0; i < MAX_WEDGE_TYPES; i++) {
+      buf +=  put_num(buf, 0, params.signflip[i], 0);
+      if (i < MAX_WEDGE_TYPES - 1) *(buf++) = ',';
+    }
+  }
+
+  buf += put_str(buf, "]\n");
+
+  // buf += put_str(buf, "\"masks\": [");
+
+  // for (i = 0; i < 2; i++) {
+  //   buf +=  put_num(buf, 0, params.masks[i], 0);
+  //   if (i < 2 - 1) *(buf++) = ',';
+  // }
+  // buf += put_str(buf, "],\n");
+
+  *(buf++) = '}';
+
+  return (int)(buf - buffer);
+}
+
+int put_wedge_params_type(char *buffer) {
+
+  char *buf = buffer;
+
+  *(buf++) = '[';
+
+  for (int i = 0; i < BLOCK_SIZES_ALL; i++) {
+    buf += put_wedge_type(buf, av1_wedge_params_lookup[i]);
+    if (i < BLOCK_SIZES_ALL - 1) *(buf++) = ',';
+  }
+
+  buf += put_str(buf, "],\n");
+
+  return (int)(buf - buffer);
+}
+
+
+
 #if CONFIG_ACCOUNTING
 int put_accounting(char *buffer) {
   char *buf = buffer;
@@ -656,6 +744,10 @@ void inspect(void *pbi, void *data) {
   if (layers & COMPOUND_TYPE_LAYER) {
     buf += put_block_info(buf, compound_type_map, "compound_type",
                           offsetof(insp_mi_data, compound_type), 0);
+    buf += snprintf(buf, MAX_BUFFER, "\"wedgeParamsLookup\": ");
+    buf += put_wedge_params_type(buf);
+    buf += put_block_info(buf, NULL, "wedge",
+                          offsetof(insp_mi_data, wedge), 2);
   }
   if (layers & SKIP_LAYER) {
     buf +=
@@ -714,6 +806,9 @@ void inspect(void *pbi, void *data) {
       snprintf(buf, MAX_BUFFER, "  \"frame\": %d,\n", frame_data.frame_number);
   buf += snprintf(buf, MAX_BUFFER, "  \"showFrame\": %d,\n",
                   frame_data.show_frame);
+  buf += put_str(buf, "  \"frame_typeMap\": {");
+  buf += put_map(buf, frame_type_map);
+  buf += put_str(buf, "},\n");
   buf += snprintf(buf, MAX_BUFFER, "  \"frameType\": %d,\n",
                   frame_data.frame_type);
   buf += snprintf(buf, MAX_BUFFER, "  \"baseQIndex\": %d,\n",
@@ -784,7 +879,15 @@ int read_frame() {
 
       have_frame = 1;
       end_frame = frame + frame_size;
-    }
+    } 
+    // else {
+
+    //   if (!aom_video_reader_read_frame(reader)) return EXIT_FAILURE;
+    //   frame = aom_video_reader_get_frame(reader, &frame_size);
+
+    //   have_frame = 1;
+    //   end_frame = frame + frame_size;
+    // }
 
     if (aom_codec_decode(&codec, frame, (unsigned int)frame_size, &adr) !=
         AOM_CODEC_OK) {

--- a/examples/inspect.c
+++ b/examples/inspect.c
@@ -625,13 +625,6 @@ int put_wedge_type(char *buffer, const wedge_params_type params) {
 
   buf += put_str(buf, "]\n");
 
-  // buf += put_str(buf, "\"masks\": [");
-
-  // for (i = 0; i < 2; i++) {
-  //   buf +=  put_num(buf, 0, params.masks[i], 0);
-  //   if (i < 2 - 1) *(buf++) = ',';
-  // }
-  // buf += put_str(buf, "],\n");
 
   *(buf++) = '}';
 

--- a/examples/inspect.c
+++ b/examples/inspect.c
@@ -872,15 +872,7 @@ int read_frame() {
 
       have_frame = 1;
       end_frame = frame + frame_size;
-    } 
-    // else {
-
-    //   if (!aom_video_reader_read_frame(reader)) return EXIT_FAILURE;
-    //   frame = aom_video_reader_get_frame(reader, &frame_size);
-
-    //   have_frame = 1;
-    //   end_frame = frame + frame_size;
-    // }
+    }
 
     if (aom_codec_decode(&codec, frame, (unsigned int)frame_size, &adr) !=
         AOM_CODEC_OK) {


### PR DESCRIPTION
Extract compound-types metadata.

The compound mode in AV1 has a wedge mode. The wedge mode has different types of wedges specified by their wedge index and wedge sign. In addition to this, each wedge index has a different shape depending on the type of block. Thus, the wedge codebook is also extracted on each frame as "wedge_types"